### PR TITLE
Set JobName with analysis name instead of description

### DIFF
--- a/public/scala/src/org/broadinstitute/sting/queue/engine/drmaa/DrmaaJobRunner.scala
+++ b/public/scala/src/org/broadinstitute/sting/queue/engine/drmaa/DrmaaJobRunner.scala
@@ -43,14 +43,13 @@ class DrmaaJobRunner(val session: Session, val function: CommandLineFunction) ex
   // Set the display name to < 512 characters of the description
   // NOTE: Not sure if this is configuration specific?
   protected val jobNameLength = 500
-  protected val jobNameFilter = """[^A-Za-z0-9_]"""
   protected def functionNativeSpec = function.jobNativeArgs.mkString(" ")
 
   def start() {
     session.synchronized {
       val drmaaJob: JobTemplate = session.createJobTemplate
 
-      drmaaJob.setJobName(function.description.take(jobNameLength).replaceAll(jobNameFilter, "_"))
+      drmaaJob.setJobName(function.analysisName.take(jobNameLength))
 
       // Set the current working directory
       drmaaJob.setWorkingDirectory(function.commandDirectory.getPath)


### PR DESCRIPTION
I found out when trying to set the job names from something more legible that the `CommandLineFunction` trait overrides the description of the `QFunction` with it's command line. This makes it difficult to parse the logs for run times from programs, projects, etc from our cluster logs (a SLURM cluster). I would therefore like to propose the following change; that the jobname submitted to the cluster should be based on the analysis name, rather than the description, so that one can do something along these lines:

```
case class MyAwesomeProgram extends CommandlineFunction {
    this.analysisName = "MyAwesomeProgram"
    def commandLine = "/my/path/program <etc>"
}
```

This would then show up as "MyAwesomeProgram" in the job-queue, logs etc.

If I'm the only one who has found this frustrating I can implement these changes only in my own branch, but I'm sending this pull request to see if there is any general interest in this change.
