### PR TITLE
Removed setting a default queue in PbsEngineJobRunner

### DIFF
--- a/public/queue-framework/src/main/scala/org/broadinstitute/sting/queue/engine/pbsengine/PbsEngineJobRunner.scala
+++ b/public/queue-framework/src/main/scala/org/broadinstitute/sting/queue/engine/pbsengine/PbsEngineJobRunner.scala
@@ -54,8 +54,6 @@ class PbsEngineJobRunner(session: Session, function: CommandLineFunction) extend
     // If the job queue is set specify the job queue
     if (function.jobQueue != null)
       nativeSpec += " -q " + function.jobQueue
-    else
-      nativeSpec += " -q normal "	
 
     // If the resident set size is requested pass on the memory request
     // mem_free is the standard, but may also be virtual_free or even not available


### PR DESCRIPTION
Discussed here:
http://gatkforums.broadinstitute.org/discussion/3959/would-it-be-possible-for-pbsengine-jobrunner-not-to-set-a-default-queue
