### PR TITLE
Switches default value for outputRoot in SplitSamFile to an empty string instead of null.

### DIFF
--- a/public/gatk-framework/src/main/java/org/broadinstitute/sting/gatk/walkers/readutils/SplitSamFile.java
+++ b/public/gatk-framework/src/main/java/org/broadinstitute/sting/gatk/walkers/readutils/SplitSamFile.java
@@ -57,7 +57,7 @@ import java.util.Map;
 @Requires({DataSource.READS})
 public class SplitSamFile extends ReadWalker<SAMRecord, Map<String, SAMFileWriter>> {
     @Argument(fullName="outputRoot", doc="output BAM file", required=false)
-    public String outputRoot = null;
+    public String outputRoot = "";
 
     @Argument(fullName = "bam_compression", shortName = "compress", doc = "Compression level to use for writing BAM files", required = false)
     public Integer BAMcompression = 5;    


### PR DESCRIPTION
Currently if outputRoot is not provided individual BAM files are named like this:
nullSAMPLE1.bam
nullSAMPLE2.bam
