### PR TITLE
Upgrade SLF4J to allow new convient logging syntaxes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,20 @@
                                 <excludes>${resource.bundle.path}</excludes>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>src-dependencies</id>
+                            <goals>
+                                <!-- use copy-dependencies instead if you don't want to explode the sources -->
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <phase>none</phase>
+                            <configuration>
+                                <classifier>sources</classifier>
+                                <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                                <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                                <includeGroupIds>${project.groupId}</includeGroupIds>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
                 <!-- TODO: Change the ResourceBundleExtractorDoclet to not require log4j.properties file -->
@@ -409,6 +423,18 @@
                                 </descriptors>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>source-dist</id>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                            <phase>none</phase>
+                            <configuration>
+                                <descriptors>
+                                    <descriptor>src/main/assembly/source-dist.xml</descriptor>
+                                </descriptors>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
 
@@ -452,6 +478,21 @@
                             </configuration>
                         </execution>
                         <execution>
+                            <id>link-source-jar</id>
+                            <goals>
+                                <goal>link</goal>
+                            </goals>
+                            <phase>none</phase>
+                            <configuration>
+                                <links>
+                                    <link>
+                                        <dst>${gatk.basedir}/target/${gatk.binary-dist.name}-sources.${project.packaging}</dst>
+                                        <src>${project.build.directory}/${project.build.finalName}-source-dist.${project.packaging}</src>
+                                    </link>
+                                </links>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>link-git-release</id>
                             <goals>
                                 <goal>link</goal>
@@ -460,7 +501,7 @@
                             <configuration>
                                 <links>
                                     <link>
-                                        <dst>${project.build.directory}/${gatk.binary-dist.name}-${build.version}.tar.bz2</dst>
+                                        <dst>${gatk.basedir}/target/${gatk.binary-dist.name}-${build.version}.tar.bz2</dst>
                                         <src>${project.build.directory}/${project.build.finalName}-binary-dist.tar.bz2</src>
                                     </link>
                                 </links>
@@ -613,28 +654,23 @@
                                 <file>${project.build.directory}/${project.build.finalName}.${project.packaging}</file>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>install-source</id>
+                            <goals>
+                                <goal>install-file</goal>
+                            </goals>
+                            <phase>none</phase>
+                            <configuration>
+                                <classifier>sources</classifier>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                                <packaging>${project.packaging}</packaging>
+                                <file>${project.build.directory}/${project.build.finalName}-source-dist.${project.packaging}</file>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
-                    <executions>
-                      <execution>
-                        <id>enforce-java</id>
-                        <goals>
-                          <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                          <rules>
-                            <requireJavaVersion>
-                              <version>[1.7.0,)</version>
-                            </requireJavaVersion>
-                          </rules>
-                        </configuration>
-                      </execution>
-                    </executions>
-              </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -615,6 +615,26 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                      <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                          <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                          <rules>
+                            <requireJavaVersion>
+                              <version>[1.7.0,)</version>
+                            </requireJavaVersion>
+                          </rules>
+                        </configuration>
+                      </execution>
+                    </executions>
+              </plugin>
             </plugins>
         </pluginManagement>
 

--- a/protected/gatk-package-distribution/pom.xml
+++ b/protected/gatk-package-distribution/pom.xml
@@ -172,6 +172,10 @@
                         <id>unpack-direct-dependencies</id>
                         <phase>${gatk.unpack.phase}</phase>
                     </execution>
+                    <execution>
+                        <id>src-dependencies</id>
+                        <phase>${gatk.unpack.phase}</phase>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -194,6 +198,10 @@
                         <id>binary-dist</id>
                         <phase>${gatk.shade.phase}</phase>
                     </execution>
+                    <execution>
+                        <id>source-dist</id>
+                        <phase>${gatk.shade.phase}</phase>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -203,6 +211,10 @@
                 <executions>
                     <execution>
                         <id>link-binary-jar</id>
+                        <phase>${gatk.shade.phase}</phase>
+                    </execution>
+                    <execution>
+                        <id>link-source-jar</id>
                         <phase>${gatk.shade.phase}</phase>
                     </execution>
                     <execution>
@@ -222,6 +234,10 @@
                     </execution>
                     <execution>
                         <id>install-package</id>
+                        <phase>install</phase>
+                    </execution>
+                    <execution>
+                        <id>install-source</id>
                         <phase>install</phase>
                     </execution>
                 </executions>

--- a/protected/gatk-package-distribution/src/main/assembly/source-dist.xml
+++ b/protected/gatk-package-distribution/src/main/assembly/source-dist.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>source-dist</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/sources</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>
+                    org/broadinstitute/gatk/**/*
+                </include>
+            </includes>
+
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/protected/gatk-queue-package-distribution/pom.xml
+++ b/protected/gatk-queue-package-distribution/pom.xml
@@ -179,6 +179,10 @@
                         <id>unpack-direct-dependencies</id>
                         <phase>${gatk.unpack.phase}</phase>
                     </execution>
+                    <execution>
+                        <id>src-dependencies</id>
+                        <phase>${gatk.unpack.phase}</phase>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -192,13 +196,16 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>binary-dist</id>
+                        <phase>${gatk.shade.phase}</phase>
+                    </execution>
+                    <execution>
+                        <id>source-dist</id>
                         <phase>${gatk.shade.phase}</phase>
                     </execution>
                 </executions>
@@ -210,6 +217,10 @@
                 <executions>
                     <execution>
                         <id>link-binary-jar</id>
+                        <phase>${gatk.shade.phase}</phase>
+                    </execution>
+                    <execution>
+                        <id>link-source-jar</id>
                         <phase>${gatk.shade.phase}</phase>
                     </execution>
                     <execution>
@@ -231,6 +242,17 @@
                         <id>install-package</id>
                         <phase>install</phase>
                     </execution>
+                    <execution>
+                        <id>install-source</id>
+                        <phase>install</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
                 </executions>
             </plugin>
 

--- a/protected/gatk-queue-package-distribution/src/main/assembly/source-dist.xml
+++ b/protected/gatk-queue-package-distribution/src/main/assembly/source-dist.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>source-dist</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/sources</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>
+                    org/broadinstitute/gatk/**/*
+                </include>
+            </includes>
+
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/public/gatk-root/pom.xml
+++ b/public/gatk-root/pom.xml
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.6.1</version>
+                <version>1.7.5</version>
             </dependency>
             <dependency>
                 <groupId>gov.nist.math</groupId>


### PR DESCRIPTION
Current SLF4J version does not allow this syntax:

`logger.debug("A string message, var1 value: {}, var2 value:{}, var3 value: {}", var1, var2, var3)`. 

This upgrade still is backward compatible with existing code. However, if not upgrading it will conflict with libraries using higher SLF4J versions and the syntax above.

Furthermore, some discussion about the advantages of upgrading to at least version 1.7.5 are in here:  
http://www.slf4j.org/faq.html#logging_performance

And actually, it is possible to migrate completely to SLF4J from Log4j as shown here: http://www.slf4j.org/migrator.html