### PR TITLE
Close (flush) BQSRGatherer's PrintStream when finished

### DIFF
--- a/public/gatk-engine/src/main/java/org/broadinstitute/gatk/engine/recalibration/BQSRGatherer.java
+++ b/public/gatk-engine/src/main/java/org/broadinstitute/gatk/engine/recalibration/BQSRGatherer.java
@@ -62,6 +62,7 @@ public class BQSRGatherer extends Gatherer  {
         }
         final GATKReport report = gatherReport(inputs);
         report.print(outputFile);
+        outputFile.close();
     }
 
     /**


### PR DESCRIPTION
Without this patch the stream is only closed (thus, flushed) when the
object is garbage collected. This is problematic when subsequent jobs
proceed and expect the output to be available, for example
AnalyzeCovariates. We see failures in approximately 50% of runs due to
this issue and they are confirmed as fixed when applying the patch (on
a busy machine using NFS storage).